### PR TITLE
Collapse State Tree by default

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -129,6 +129,7 @@ export default class ReduxViewer extends FlipperPlugin<State, any, any> {
                 <Tab label="State Tree">
                   <ManagedDataInspector
                     data={selectedData.after}
+                    collapsed={true}
                     expandRoot={false}
                   />
                 </Tab>


### PR DESCRIPTION
I noticed that Flipper gets slow and laggy if the State Tree is too large.
The idea is to collapse the objects by default, and only expand them if the user decides to.