### PR TITLE
Add key filter to sidebar and change add-color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
 # Redux Debugger Plugin for Flipper
 
-## What does this fork change compared to the original one?
-* Add filter to the sidebar to allow filtering by state keys. This makes life a lot easier, especially with bigger apps / lots of states
-* Change "Add" color to green to make more visible which data has been added (green) and which data has been removed (red)
-
-![30-18-nsbae-ec3om](https://user-images.githubusercontent.com/12933672/215464164-76e42927-9dbf-4e4b-9566-1be4688bd307.gif)
-![redux-debugger-change-arrows](https://user-images.githubusercontent.com/12933672/215464566-d927be99-92e2-477f-911b-fbde6a05dfd4.png)
-
-
-
-## Original README ⤵️
-
 ![screenshot of the plugin](https://i.imgur.com/blqn8oT.png)
 
 `flipper-plugin-redux-debugger` allows you read React Native redux logs inside [Flipper](https://fbflipper.com/) now:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # Redux Debugger Plugin for Flipper
 
+## What does this fork change compared to the original one?
+* Add filter to the sidebar to allow filtering by state keys. This makes life a lot easier, especially with bigger apps / lots of states
+* Change "Add" color to green to make more visible which data has been added (green) and which data has been removed (red)
+
+![30-18-nsbae-ec3om](https://user-images.githubusercontent.com/12933672/215464164-76e42927-9dbf-4e4b-9566-1be4688bd307.gif)
+![redux-debugger-change-arrows](https://user-images.githubusercontent.com/12933672/215464566-d927be99-92e2-477f-911b-fbde6a05dfd4.png)
+
+
+
+## Original README ⤵️
+
 ![screenshot of the plugin](https://i.imgur.com/blqn8oT.png)
 
 `flipper-plugin-redux-debugger` allows you read React Native redux logs inside [Flipper](https://fbflipper.com/) now:

--- a/index.tsx
+++ b/index.tsx
@@ -112,7 +112,7 @@ export function plugin(client: PluginClient<Events, {}>) {
           actionPayload = payloadStringValue.trim() == "" ? [] : JSON.parse(payloadStringValue);
         } catch (e) {
           // can happen when we try to parse a string input
-          message.error("Ivalid JSON format in the payload");
+          message.error("Invalid JSON format in the payload");
           actionPayload = payloadStringValue;
         }
 
@@ -157,9 +157,9 @@ export function Component() {
   const actionType = useValue(instance.actionType);
   const actionPayloadString = useValue(instance.actionPayloadString);
 
-  const rows = useMemoize(actions => createRows(actions), [actions]);
+  const rows = useMemoize((actions) => createRows(actions), [actions]);
 
-  const selectedData = actions.find(act => act.id === selectedId);
+  const selectedData = actions.find((act) => act.id === selectedId);
   return (
     <>
       <Panel title="Dispatch Action to the app" gap pad>
@@ -174,7 +174,7 @@ export function Component() {
         enableAutoScroll={true}
         enableMultiSelect={false}
         enableColumnHeaders={true}
-        onSelect={record => {
+        onSelect={(record) => {
           instance.setSelection(record?.id);
         }}
         extraActions={<Button onClick={instance.clearAction}>Clear</Button>}
@@ -220,7 +220,7 @@ function renderSidebar(selectedData: ActionState) {
     return;
   }
 
-  const {type, ...payload} = selectedData?.action;
+  const { type, ...payload } = selectedData?.action;
   const actionData = {
     type,
     payload,


### PR DESCRIPTION
## What has changed?
* Add **filter** to the sidebar to allow filtering/search for state keys. This makes life a lot easier, especially with bigger apps / lots of states
* Change **"Add" color** to green (before it was orange) to make more visible which data has been added (green) and which data has been removed (red)

![30-18-nsbae-ec3om](https://user-images.githubusercontent.com/12933672/215464164-76e42927-9dbf-4e4b-9566-1be4688bd307.gif)
![redux-debugger-change-arrows](https://user-images.githubusercontent.com/12933672/215464566-d927be99-92e2-477f-911b-fbde6a05dfd4.png)